### PR TITLE
community: update _get_node_import_query cypher

### DIFF
--- a/libs/community/langchain_community/graphs/neo4j_graph.py
+++ b/libs/community/langchain_community/graphs/neo4j_graph.py
@@ -130,10 +130,16 @@ def value_sanitize(d: Any) -> Any:
 def _get_node_import_query(baseEntityLabel: bool, include_source: bool) -> str:
     if baseEntityLabel:
         return (
-            f"{include_docs_query if include_source else ''}"
+           f"{include_docs_query if include_source else ''}"
             "UNWIND $data AS row "
+            # Attempt to MATCH the node first
+            f"MATCH (existingSource:`{BASE_ENTITY_LABEL}` {{id: row.id}}) "
+            "WITH existingSource, row "
+            "WHERE existingSource IS NULL "
+            # If no match is found, create a new node using MERGE
             f"MERGE (source:`{BASE_ENTITY_LABEL}` {{id: row.id}}) "
-            "SET source += row.properties "
+            "ON CREATE SET source += row.properties "  # Set properties when created
+            "ON MATCH SET source += row.properties "   # Update properties if matched
             f"{'MERGE (d)-[:MENTIONS]->(source) ' if include_source else ''}"
             "WITH source, row "
             "CALL apoc.create.addLabels( source, [row.type] ) YIELD node "


### PR DESCRIPTION
community: update _get_node_import_query cypher

- **Description:** changed the community/graph/neo4j_graph.py  _get_node_import_query function's cypher.
- **Issue:** solve the error of adding a new relationship to an existing node. 
solve the error of adding a new relationship to an existing node. problem ref: https://www.reddit.com/r/Neo4j/comments/1aliv90/error_creating_duplicate/


- **Add tests and docs**:   
                - before cyper will result in: 
                - neo4j.exceptions.ConstraintError: {code: Neo.ClientError.Schema.ConstraintValidationFailed} {message: Node(9898) already exists with label `__Entity__` and property `id` = 'M8009C7'}   
               - now there is no error


